### PR TITLE
DEVEXP-136 Using string converter in source connector examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ You can also manually configure an instance of the source connector:
 2. Click on the "connect-default" cluster
 3. Click on "Add connector"
 4. Click on "MarkLogicSourceConnector"
-5. For "Value converter class", enter `org.apache.kafka.connect.json.JsonConverter`
+5. For "Value converter class", enter `org.apache.kafka.connect.storage.StringConverter`
 6. Under "General", enter values for the required MarkLogic connection fields
 7. Enter an Optic DSL query for `ml.source.optic.dsl` and a Kafka topic name for `ml.source.topic`
 8. Add values for any optional fields that you wish to populate

--- a/src/main/java/com/marklogic/kafka/connect/source/CsvRowBatcherBuilder.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/CsvRowBatcherBuilder.java
@@ -30,7 +30,6 @@ public class CsvRowBatcherBuilder extends AbstractRowBatcherBuilder<String> {
 
     private void onSuccessHandler(RowBatchSuccessListener.RowBatchResponseEvent<String> event, List<SourceRecord> newSourceRecords) {
         String document = event.getRowsDoc();
-        logger.debug("CSV document: \n" + document);
         BufferedReader reader = new BufferedReader(new StringReader(document));
         try {
             String headers = reader.readLine();

--- a/src/main/java/com/marklogic/kafka/connect/source/JsonRowBatcherBuilder.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/JsonRowBatcherBuilder.java
@@ -28,15 +28,13 @@ public class JsonRowBatcherBuilder extends AbstractRowBatcherBuilder<JsonNode> {
 
     private void onSuccessHandler(RowBatchSuccessListener.RowBatchResponseEvent<JsonNode> event, List<SourceRecord> newSourceRecords) {
         JsonNode rows = event.getRowsDoc().get("rows");
-        logger.debug("JsonNode: \n" + rows.toPrettyString());
-
         for (JsonNode row : rows) {
-// We may need to add a switch to include a key in the record depending on how the target topic is configured.
-// If the topic's cleanup policy is set to "compact", then a key is required to be included in the SourceRecord.
-//            String key = event.getJobBatchNumber() + "-" + rowNumber;
-
-            // Calling toString on the JsonNode, as when this is run in Confluent Platform, we get the following
-            // error: org.apache.kafka.connect.errors.DataException: Java class com.fasterxml.jackson.databind.node.ObjectNode does not have corresponding schema type.
+            /**
+             * Testing has shown that converting the JSON to a string and using
+             * org.apache.kafka.connect.storage.StringConverter as the value converter works well. And a user could
+             * still choose to use org.apache.kafka.connect.json.JsonConverter, though they would most likely want
+             * to set "value.converter.schemas.enable" to "false".
+             */
             try {
                 SourceRecord newRecord = new SourceRecord(null, null, topic, null, row.toString());
                 newSourceRecords.add(newRecord);

--- a/src/test/resources/confluent/marklogic-authors-source.json
+++ b/src/test/resources/confluent/marklogic-authors-source.json
@@ -3,7 +3,7 @@
   "config": {
     "connector.class": "com.marklogic.kafka.connect.source.MarkLogicSourceConnector",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
-    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "tasks.max": "1",
     "ml.connection.host": "localhost",
     "ml.connection.port": 8018,

--- a/src/test/resources/confluent/marklogic-purchases-source.json
+++ b/src/test/resources/confluent/marklogic-purchases-source.json
@@ -3,7 +3,7 @@
   "config": {
     "connector.class": "com.marklogic.kafka.connect.source.MarkLogicSourceConnector",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
-    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "tasks.max": "1",
     "ml.connection.host": "localhost",
     "ml.connection.port": 8018,


### PR DESCRIPTION
And added a note to JsonRowBatcherBuilder to explain why a source connector is fine and how a user can still use JsonConverter if desired. 

Also removed debug logging of data, as we can't leave that in and risk printing sensitive data. 