### PR TITLE
Using trace for some verbose sink logging

### DIFF
--- a/src/main/java/com/marklogic/kafka/connect/sink/AbstractSinkTask.java
+++ b/src/main/java/com/marklogic/kafka/connect/sink/AbstractSinkTask.java
@@ -107,8 +107,8 @@ abstract class AbstractSinkTask extends SinkTask {
             sinkRecord.headers().forEach(header -> headers.add(String.format("%s:%s", header.key(), header.value().toString())));
             logger.info("Record headers: {}", headers);
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug("Processing record value {} in topic {}", sinkRecord.value(), sinkRecord.topic());
+        if (logger.isTraceEnabled()) {
+            logger.trace("Processing record value {} in topic {}", sinkRecord.value(), sinkRecord.topic());
         }
     }
 


### PR DESCRIPTION
"debug" is helpful on the source side for seeing some info on each poll call. But the "Processing record" message in the sink connector shows up for every single sink record; that can quickly become overwhelming. So shifted that to "trace". 