### PR TITLE
DEVEXP-652 Bumped to Java Client 6.3.0 to address vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
   id 'java'
   id 'net.saliman.properties' version '1.5.2'
-  id 'com.github.johnrengelman.shadow' version '7.1.2'
+  id 'com.github.johnrengelman.shadow' version '8.1.1'
   id "com.github.jk1.dependency-license-report" version "1.19"
 
   // Only used for testing
-  id 'com.marklogic.ml-gradle' version '4.5.0'
+  id 'com.marklogic.ml-gradle' version '4.6.0'
   id 'jacoco'
   id "org.sonarqube" version "3.5.0.2730"
 
@@ -23,19 +23,6 @@ java {
 
 repositories {
   mavenCentral()
-
-  // For testing
-  mavenLocal()
-  maven {
-    url "https://nexus.marklogic.com/repository/maven-snapshots/"
-  }
-}
-
-// Do not cache changing modules
-configurations.all {
-  resolutionStrategy {
-    cacheChangingModulesFor 0, 'seconds'
-  }
 }
 
 configurations {
@@ -44,7 +31,7 @@ configurations {
 }
 
 ext {
-  kafkaVersion = "3.2.3"
+  kafkaVersion = "3.5.1"
 }
 
 dependencies {
@@ -53,11 +40,11 @@ dependencies {
   compileOnly "org.apache.kafka:connect-runtime:${kafkaVersion}"
   compileOnly "org.slf4j:slf4j-api:1.7.36"
 
-  implementation 'com.marklogic:ml-javaclient-util:4.5.0'
+  implementation 'com.marklogic:ml-javaclient-util:4.6.0'
   // Force DHF to use the latest version of ml-app-deployer, which minimizes security vulnerabilities
-  implementation "com.marklogic:ml-app-deployer:4.5.0"
+  implementation "com.marklogic:ml-app-deployer:4.6.0"
 
-  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.1"
+  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.15.2"
 
   // Note that in general, the version of the DHF jar must match that of the deployed DHF instance. Different versions
   // may work together, but that behavior is not guaranteed.
@@ -72,11 +59,11 @@ dependencies {
     exclude module: "logback-classic"
   }
 
-  testImplementation 'com.marklogic:marklogic-junit5:1.3.0'
+  testImplementation 'com.marklogic:marklogic-junit5:1.4.0'
 
   testImplementation "org.apache.kafka:connect-api:${kafkaVersion}"
   testImplementation "org.apache.kafka:connect-json:${kafkaVersion}"
-  testImplementation 'net.mguenther.kafka:kafka-junit:3.2.2'
+  testImplementation 'net.mguenther.kafka:kafka-junit:3.5.1'
 
   testImplementation "org.apache.avro:avro-compiler:1.11.1"
 
@@ -113,7 +100,8 @@ jacocoTestReport {
 // Enabling the XML report allows for sonar to grab coverage data from jacoco
 jacocoTestReport {
   reports {
-    xml.enabled true
+    // This isn't working with Gradle 8. Will replace this soon with the sonar instance in docker-compose.
+    // xml.enabled true
   }
 }
 
@@ -220,8 +208,8 @@ task connectorArchive(type: Zip, dependsOn: connectorArchive_BuildDirectory, gro
   description = 'Build a Connector Hub for the Confluent Connector Hub'
   from "${baseArchiveBuildDir}"
   include '**/*'
-  archiveName "${baseArchiveName}.zip"
-  destinationDir(file('build/distro'))
+  archiveFileName = "${baseArchiveName}.zip"
+  destinationDirectory = file('build/distro')
 }
 
 task installConnectorInConfluent(type: Exec, group: confluentTestingGroup, dependsOn: [connectorArchive]) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.marklogic
-version=1.8.0
+version=1.8-SNAPSHOT
 
 # For the Confluent Connector Archive
 componentOwner=marklogic

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Addresses the vulnerability in okio, which is fixed in Java Client 6.3.0. 

Had to bump Gradle to 8 to allow for uber jar to be built, now that Jackson 2.15 is used by the Java Client (we did the same thing for our Spark connector). 

Everything in the CONTRIB ran fine, no issues encountered. 