### PR TITLE
MLE-23377 - Bump Kafka to 3.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ configurations {
 }
 
 ext {
-  kafkaVersion = "3.8.1"
+  kafkaVersion = "3.9.1"
 }
 
 dependencies {


### PR DESCRIPTION
Start simple and see what this does to the BlackDuck report.
Both the automated tests and the manual testing were successful locally.