### PR TITLE
MLE-23377 - Bump Kafka to 3.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,17 +27,23 @@ configurations {
   documentation
   assets
 
-  // Force v3.18 of commons-lang3 to avoid security vulnerabilities, without also
-  // upgrading ml-app-deployer to 6.0.0, which we are not ready to do yet.
   configurations.all {
     resolutionStrategy {
-        force 'org.apache.commons:commons-lang3:3.18.0'
+      // Force v4.5.0 of commons-collections4 to avoid CVEs in v4.4.0 from transitive dependecies:
+      // CVE-2025-48924 (https://www.cve.org/CVERecord?id=CVE-2025-48924) and
+      // CVE-2020-15250 (https://www.cve.org/CVERecord?id=CVE-2020-15250)
+      force "org.apache.commons:commons-collections4:4.5.0"
+
+      // Force v3.18 of commons-lang3 to avoid CVE-2025-48924
+      // (https://www.cve.org/CVERecord?id=CVE-2025-48924), without also
+      // upgrading ml-app-deployer to 6.0.0, which we are not ready to do yet.
+      force 'org.apache.commons:commons-lang3:3.18.0'
     }
   }
 }
 
 ext {
-  kafkaVersion = "3.8.1"
+  kafkaVersion = "3.9.1"
 }
 
 dependencies {
@@ -71,7 +77,7 @@ dependencies {
   testImplementation "org.apache.avro:avro-compiler:1.12.0"
 
   // Forcing logback to be used for test logging
-  testImplementation "ch.qos.logback:logback-classic:1.3.14"
+  testImplementation "ch.qos.logback:logback-classic:1.5.18"
   testImplementation "org.slf4j:jcl-over-slf4j:2.0.16"
 
   documentation files('LICENSE.txt')


### PR DESCRIPTION
Also, forced the latest commons-collection4 and upgraded to the latest logback version.

This leaves a single "medium" security risk (spring-framework) that will be addressed next.
