### PR TITLE
MLE-24529 - Force newer jetty and netty libraries to avoid CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,25 @@ configurations {
       // Force v3.19 of commons-lang3 to avoid CVE-2025-48924 (https://www.cve.org/CVERecord?id=CVE-2025-48924), which
       // is caused by the use of avro-compiler v1.12.0 with older dependencies including commons-lang3 v3.12.0.
       force 'org.apache.commons:commons-lang3:3.19.0'
+
+      resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        // Force v12.1.1 of jetty-http to avoid CVE-2025-5115
+        // (https://nvd.nist.gov/vuln/detail/CVE-2025-5115), which is a transitive
+        // dependency of Kafka connect-runtime:4.1.0
+        // Need to ensure this inclusdes all jetty modules, such as "org.eclipse.jetty.ee10"
+        if (details.requested.group.startsWith("org.eclipse.jetty") && details.requested.version.startsWith("12")) {
+          details.useVersion "12.1.1"
+          details.because "Bumping from 12.0.22 (what Kafka connect-runtime:4.1.0 depends on) to 12.1.1 to eliminate CVEs."
+        }
+
+        // Force v4.2.6.Final of netty-all to avoid CVE-2025-58057
+        // (https://www.cve.org/CVERecord?id=CVE-2025-58057), which is a transitive
+        // dependency of marklogic-data-hub:6.2.1      
+        if (details.requested.group.equals("io.netty") && details.requested.version.startsWith("4")) {
+          details.useVersion "4.2.6.Final"
+          details.because "Bumping from 4.1.0 (what marklogic-data-hub:6.2.1 depends on) to 4.2.6.Final to eliminate CVEs."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
org.eclipse.jetty:jetty-http:12.1.1
io.netty:netty-all:4.2.6.Final
