### PR TITLE
MLE-29670 Sanitize column names to protect against injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docker/marklogic
 bin
 .vscode
 *.class
+.codesight/
 
 .classpath
 

--- a/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
@@ -109,20 +109,21 @@ public class MarkLogicSourceConfig extends MarkLogicConfig {
 
     /**
      * Validator for constraint column names to prevent NoSQL/DSL injection attacks (CWE-89/CWE-943).
-     * Ensures column names match a strict allowlist pattern: alphanumeric, underscore, dot, and hyphen characters only.
-     * Maximum length is 128 characters to prevent potential buffer overflow issues.
+     * Ensures column names match a strict allowlist pattern that supports valid MarkLogic Optic identifiers,
+     * including namespaced/QName-style names containing a colon, plus alphanumeric, underscore, dot, and hyphen characters.
+     * Maximum length is 128 characters to prevent excessively long values.
      */
     public static class ConstraintColumnNameValidator implements ConfigDef.Validator {
-        private static final String COLUMN_NAME_PATTERN = "^[a-zA-Z0-9_.-]{1,128}$";
+        private static final String COLUMN_NAME_PATTERN = "^[a-zA-Z0-9_.:-]{1,128}$";
 
         public void ensureValid(String name, Object value) {
             if (StringUtils.hasText((String) value)) {
                 String columnName = (String) value;
                 if (!columnName.matches(COLUMN_NAME_PATTERN)) {
                     throw new ConfigException(format(
-                        "Invalid constraint column name '%s'. Column names must be alphanumeric (a-zA-Z0-9), " +
-                        "underscore (_), dot (.), or hyphen (-), and between 1-128 characters long. " +
-                        "This validation prevents DSL injection attacks.",
+                        "Invalid constraint column name '%s'. Column names must contain only alphanumeric (a-zA-Z0-9), " +
+                        "underscore (_), dot (.), hyphen (-), or colon (:) characters, and be between 1-128 characters long. " +
+                        "This validation prevents DSL injection attacks while allowing valid MarkLogic Optic column identifiers.",
                         columnName));
                 }
             }

--- a/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
+++ b/src/main/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2019-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.kafka.connect.source;
 
@@ -74,7 +74,7 @@ public class MarkLogicSourceConfig extends MarkLogicConfig {
                 "Set to true for column types to be included in the value of each source record; has no effect if the output " +
                     "format is CSV",
                 GROUP, -1, ConfigDef.Width.MEDIUM, "Include Column Types")
-            .define(CONSTRAINT_COLUMN_NAME, Type.STRING, null, Importance.HIGH,
+            .define(CONSTRAINT_COLUMN_NAME, Type.STRING, null, new ConstraintColumnNameValidator(), Importance.HIGH,
                 "The name of the column which should be used to constrain the Optic query; typically used when only " +
                     "new or modified data should be returned.",
                 GROUP, -1, ConfigDef.Width.MEDIUM, "Constraint Column Name")
@@ -102,6 +102,28 @@ public class MarkLogicSourceConfig extends MarkLogicConfig {
                     metadata.getPermissions().addFromDelimitedString((String) value);
                 } catch (IllegalArgumentException ex) {
                     throw new ConfigException(ex.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Validator for constraint column names to prevent NoSQL/DSL injection attacks (CWE-89/CWE-943).
+     * Ensures column names match a strict allowlist pattern: alphanumeric, underscore, dot, and hyphen characters only.
+     * Maximum length is 128 characters to prevent potential buffer overflow issues.
+     */
+    public static class ConstraintColumnNameValidator implements ConfigDef.Validator {
+        private static final String COLUMN_NAME_PATTERN = "^[a-zA-Z0-9_.-]{1,128}$";
+
+        public void ensureValid(String name, Object value) {
+            if (StringUtils.hasText((String) value)) {
+                String columnName = (String) value;
+                if (!columnName.matches(COLUMN_NAME_PATTERN)) {
+                    throw new ConfigException(format(
+                        "Invalid constraint column name '%s'. Column names must be alphanumeric (a-zA-Z0-9), " +
+                        "underscore (_), dot (.), or hyphen (-), and between 1-128 characters long. " +
+                        "This validation prevents DSL injection attacks.",
+                        columnName));
                 }
             }
         }

--- a/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2019-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.kafka.connect.source;
 
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     private static final String CONSTRAINT_COLUMN = "ID";
@@ -143,5 +144,81 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
 
         verifyQueryReturnsExpectedRows(null, 3, "First", parsedConfig);
         verifyQueryReturnsExpectedRows(CONSTRAINT_VALUE, 1, "Third", parsedConfig);
+    }
+
+    @Test
+    void rejectionOfDslInjectionInConstraintColumnNameViaConfig() {
+        // This test verifies that the fix for CWE-89 / CWE-943 (DSL Injection) works correctly.
+        // The constraint column name is validated at configuration parse time to prevent injection attacks.
+        // See: https://github.com/marklogic/kafka-marklogic-connector/issues/XXX
+        
+        // Malicious payload: ')) .joinInner(op.fromView('sensitive', 'secrets')).select([op.col('secret_value
+        // This would attempt to join a sensitive view and exfiltrate data
+        Map<String, Object> configWithInjectionAttempt = new HashMap<String, Object>() {{
+            put(MarkLogicSourceConfig.CONNECTION_HOST, "localhost");
+            put(MarkLogicSourceConfig.CONNECTION_PORT, "8000");
+            put(MarkLogicSourceConfig.DSL_QUERY, "op.fromView('Medical', 'Authors')");
+            put(MarkLogicSourceConfig.TOPIC, "Authors");
+            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "')) .joinInner(op.fromView('sensitive', 'secrets')).select([op.col('secret_value");
+        }};
+        
+        // Config parsing should throw an exception when the injection attempt is detected
+        org.apache.kafka.common.config.ConfigException exception = 
+            org.junit.jupiter.api.Assertions.assertThrows(
+                org.apache.kafka.common.config.ConfigException.class,
+                () -> MarkLogicSourceConfig.CONFIG_DEF.parse(configWithInjectionAttempt),
+                "Configuration validation should reject DSL injection attempts in constraintColumnName");
+        
+        // Verify the error message is helpful
+        assertTrue(exception.getMessage().contains("Invalid constraint column name"), 
+            "Error message should indicate the column name is invalid");
+    }
+
+    @Test
+    void rejectionOfSqlInjectionInConstraintColumnNameViaConfig() {
+        // Another common injection pattern: SQL injection-like attempt
+        Map<String, Object> configWithSqlInjection = new HashMap<String, Object>() {{
+            put(MarkLogicSourceConfig.CONNECTION_HOST, "localhost");
+            put(MarkLogicSourceConfig.CONNECTION_PORT, "8000");
+            put(MarkLogicSourceConfig.DSL_QUERY, "op.fromView('Medical', 'Authors')");
+            put(MarkLogicSourceConfig.TOPIC, "Authors");
+            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "id'; DROP TABLE users;");
+        }};
+        
+        org.apache.kafka.common.config.ConfigException exception = 
+            org.junit.jupiter.api.Assertions.assertThrows(
+                org.apache.kafka.common.config.ConfigException.class,
+                () -> MarkLogicSourceConfig.CONFIG_DEF.parse(configWithSqlInjection),
+                "Configuration validation should reject SQL injection patterns in constraintColumnName");
+        
+        assertTrue(exception.getMessage().contains("Invalid constraint column name"),
+            "Error message should indicate the column name is invalid");
+    }
+
+    @Test
+    void acceptanceOfValidConstraintColumnNames() {
+        // Ensure that legitimate column names are still accepted
+        Map<String, Object> validConfigs = new HashMap<String, Object>() {{
+            put(MarkLogicSourceConfig.CONNECTION_HOST, "localhost");
+            put(MarkLogicSourceConfig.CONNECTION_PORT, "8000");
+            put(MarkLogicSourceConfig.DSL_QUERY, "op.fromView('Medical', 'Authors')");
+            put(MarkLogicSourceConfig.TOPIC, "Authors");
+        }};
+        
+        // Alphanumeric
+        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "ID");
+        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
+        
+        // With underscore
+        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "id_123");
+        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
+        
+        // With dot (common for qualified names)
+        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "schema.column");
+        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
+        
+        // With hyphen
+        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "my-column");
+        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
     }
 }

--- a/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/DslConstraintInjectionTest.java
@@ -150,7 +150,6 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
     void rejectionOfDslInjectionInConstraintColumnNameViaConfig() {
         // This test verifies that the fix for CWE-89 / CWE-943 (DSL Injection) works correctly.
         // The constraint column name is validated at configuration parse time to prevent injection attacks.
-        // See: https://github.com/marklogic/kafka-marklogic-connector/issues/XXX
         
         // Malicious payload: ')) .joinInner(op.fromView('sensitive', 'secrets')).select([op.col('secret_value
         // This would attempt to join a sensitive view and exfiltrate data
@@ -174,51 +173,4 @@ class DslConstraintInjectionTest extends AbstractIntegrationSourceTest {
             "Error message should indicate the column name is invalid");
     }
 
-    @Test
-    void rejectionOfSqlInjectionInConstraintColumnNameViaConfig() {
-        // Another common injection pattern: SQL injection-like attempt
-        Map<String, Object> configWithSqlInjection = new HashMap<String, Object>() {{
-            put(MarkLogicSourceConfig.CONNECTION_HOST, "localhost");
-            put(MarkLogicSourceConfig.CONNECTION_PORT, "8000");
-            put(MarkLogicSourceConfig.DSL_QUERY, "op.fromView('Medical', 'Authors')");
-            put(MarkLogicSourceConfig.TOPIC, "Authors");
-            put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "id'; DROP TABLE users;");
-        }};
-        
-        org.apache.kafka.common.config.ConfigException exception = 
-            org.junit.jupiter.api.Assertions.assertThrows(
-                org.apache.kafka.common.config.ConfigException.class,
-                () -> MarkLogicSourceConfig.CONFIG_DEF.parse(configWithSqlInjection),
-                "Configuration validation should reject SQL injection patterns in constraintColumnName");
-        
-        assertTrue(exception.getMessage().contains("Invalid constraint column name"),
-            "Error message should indicate the column name is invalid");
-    }
-
-    @Test
-    void acceptanceOfValidConstraintColumnNames() {
-        // Ensure that legitimate column names are still accepted
-        Map<String, Object> validConfigs = new HashMap<String, Object>() {{
-            put(MarkLogicSourceConfig.CONNECTION_HOST, "localhost");
-            put(MarkLogicSourceConfig.CONNECTION_PORT, "8000");
-            put(MarkLogicSourceConfig.DSL_QUERY, "op.fromView('Medical', 'Authors')");
-            put(MarkLogicSourceConfig.TOPIC, "Authors");
-        }};
-        
-        // Alphanumeric
-        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "ID");
-        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
-        
-        // With underscore
-        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "id_123");
-        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
-        
-        // With dot (common for qualified names)
-        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "schema.column");
-        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
-        
-        // With hyphen
-        validConfigs.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "my-column");
-        MarkLogicSourceConfig.CONFIG_DEF.parse(validConfigs);
-    }
 }

--- a/src/test/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfigTest.java
+++ b/src/test/java/com/marklogic/kafka/connect/source/MarkLogicSourceConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2019-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.kafka.connect.source;
 
@@ -88,6 +88,67 @@ class MarkLogicSourceConfigTest extends AbstractIntegrationSourceTest {
         Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config));
         config.put(MarkLogicSourceConfig.CONSTRAINT_STORAGE_PERMISSIONS, "testRole,read,testRole,red");
         Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config));
+    }
+
+    @Test
+    void testConstraintColumnNameValidation() {
+        ConfigDef configDef = MarkLogicSourceConfig.CONFIG_DEF;
+        Map<String, Object> config = new HashMap<>();
+        config.put(MarkLogicSourceConfig.CONNECTION_HOST, "localhost");
+        config.put(MarkLogicSourceConfig.CONNECTION_PORT, "8000");
+        config.put(MarkLogicSourceConfig.DSL_QUERY, AUTHORS_OPTIC_DSL);
+        config.put(MarkLogicSourceConfig.TOPIC, AUTHORS_TOPIC);
+
+        // Valid constraint column names
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, null);
+        configDef.parse(config); // null is allowed (optional field)
+        
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "ID");
+        configDef.parse(config); // alphanumeric
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "id_123");
+        configDef.parse(config); // with underscore
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "col.name");
+        configDef.parse(config); // with dot
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "col-name");
+        configDef.parse(config); // with hyphen
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "a");
+        configDef.parse(config); // single character
+
+        // Invalid constraint column names (DSL injection attempts)
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "')) .joinInner(op.fromView('sensitive', 'secrets')).select([op.col('secret_value");
+        Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config),
+            "Should reject column names with quotes and special characters");
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "id'; DROP TABLE users;");
+        Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config),
+            "Should reject column names with semicolons and SQL injection attempts");
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "col(name)");
+        Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config),
+            "Should reject column names with parentheses");
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "col@name");
+        Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config),
+            "Should reject column names with special characters");
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "col name");
+        Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config),
+            "Should reject column names with spaces");
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "");
+        configDef.parse(config); // empty string is treated as unset
+
+        // Test max length boundary
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "a".repeat(128));
+        configDef.parse(config); // exactly 128 characters is allowed
+
+        config.put(MarkLogicSourceConfig.CONSTRAINT_COLUMN_NAME, "a".repeat(129));
+        Assertions.assertThrows(ConfigException.class, () -> configDef.parse(config),
+            "Should reject column names exceeding 128 characters");
     }
 
 }


### PR DESCRIPTION
constraintColumnName — which comes directly from connector configuration — is string-concatenated into DSL without any sanitization