### PR TITLE
MLE-29880 and MLE-29897 Update dependencies to address security vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ configurations {
 }
 
 ext {
-  kafkaVersion = "4.1.1"
+  kafkaVersion = "4.3.0"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     exclude group: "io.netty"
   }
 
-  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.20.0"
+  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.21.3"
 
   testImplementation 'com.marklogic:marklogic-junit5:2.0-SNAPSHOT'
 


### PR DESCRIPTION
This pull request updates the version of the `jackson-dataformat-csv` dependency listed in the `NOTICE.txt` file to reflect the use of version 2.21.3 instead of 2.20.2.

Dependency version update:
* Updated Kafka version to 4.3.0
* Updated `jackson-dataformat-csv` from version 2.20.2 to 2.21.3 in the `NOTICE.txt` file to ensure accurate documentation of third-party dependencies. [[1]](diffhunk://#diff-b810ebe4ffda4293c79d292059b45b59de7e649e86314ffd5a1ee4eb4b1e08c8L15-R15) [[2]](diffhunk://#diff-b810ebe4ffda4293c79d292059b45b59de7e649e86314ffd5a1ee4eb4b1e08c8L35-R35)